### PR TITLE
Update branch alias to 2.x-dev for 2.0.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   "extra": {
     "class": "grasmash\\DrupalSecurityWarning\\Composer\\Plugin",
     "branch-alias": {
-      "dev-master": "1.x-dev"
+      "dev-master": "2.x-dev"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Updates the `dev-master` branch alias from `1.x-dev` to `2.x-dev` ahead of tagging 2.0.0.
- 2.0.0 is a major bump because #12 raised the PHP requirement to >= 8.1 and dropped Composer 1 (`composer-plugin-api ^2.0` only).

## Test plan

- [x] `composer validate` passes
- [x] `composer test` green locally (21 tests, 31 assertions)
- [ ] CI matrix + coverage gate pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)